### PR TITLE
chore: set version for components in mock-env

### DIFF
--- a/demo/pregenerated_env/mock_env/mock_instances/0/Provides
+++ b/demo/pregenerated_env/mock_env/mock_instances/0/Provides
@@ -1,2 +1,2 @@
 device_type=gateway
-artifact_name=UNSET
+version=mock-env-gateway

--- a/demo/pregenerated_env/mock_env/mock_instances/1/Provides
+++ b/demo/pregenerated_env/mock_env/mock_instances/1/Provides
@@ -1,2 +1,2 @@
 device_type=rtos
-artifact_name=UNSET
+version=mock-env-rtos

--- a/demo/pregenerated_env/mock_env/mock_instances/2/Provides
+++ b/demo/pregenerated_env/mock_env/mock_instances/2/Provides
@@ -1,2 +1,2 @@
 device_type=rtos
-artifact_name=UNSET
+version=mock-env-rtos


### PR DESCRIPTION
In order for the component to show up in the Software tab in hM it must have a `version` field. Set the initial version for each component to `mock-env-$COMPONENT_TYPE`.

Remove `artifact_name=UNSET`. We haven't installed an artifact and this is just noise.

Ticket: MEN-8693

It will look like this on first boot:
<img width="344" height="264" alt="image" src="https://github.com/user-attachments/assets/cb44f2bf-6c43-4449-840c-9243be15cb56" />
