### PR TITLE
chore: add LIC_FILES_CHKSUM file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,3 +6,4 @@ include:
       file:
         - .gitlab-ci-check-commits-signoffs.yml
         - .gitlab-ci-github-status-updates.yml
+        - .gitlab-ci-check-license.yml

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,10 @@
+                                 Copyright 2025 Northern.tech AS
+
+All content in this project is licensed under the Apache License v2, unless
+indicated otherwise.
+
+-------------------------------------------------------------------------------
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,0 +1,2 @@
+# Apache-2.0 license.
+75ca64682db23f9708fda93c8498d03e95a48ec976fc7714e2b6b60e86fbae06  LICENSE

--- a/demo/pregenerated_env/install_demo.sh
+++ b/demo/pregenerated_env/install_demo.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env sh
-# Copyright 2024 Northern.tech AS
+# Copyright 2025 Northern.tech AS
 #
-#    All Rights Reserved
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
 
 log_and_execute() {
     # Log the command to stderr


### PR DESCRIPTION
The LIC_FILES_CHKSUM is needed for the license checks in the yocto recipe.
Add license check in CI.


Ticket: MEN-7201