### PR TITLE
chore: make rtos interface shell compatible

### DIFF
--- a/demo/mock-env/interfaces/v1/rtos
+++ b/demo/mock-env/interfaces/v1/rtos
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 INTERFACE_NAME=$(basename "$0")
 STATE=$1
@@ -15,19 +15,19 @@ INSTANCE_BASE_DIR=/data/mender-orchestrator/mock-instances
 INSTANCE_DIR="$INSTANCE_BASE_DIR/$INSTANCE_ID"
 
 
-function run(){
+run(){
     local CMD=$1
     >&2 echo "Executing: $CMD"
     eval "$CMD"
 }
 
-function log(){
+log(){
     local MSG=$1
     >&2 echo "##### [$INTERFACE_NAME $INSTANCE_ID] $MSG"
 }
 
 
-function is_cmd_available() {
+is_cmd_available() {
     command -v $1 >/dev/null 2>&1 || { log "ERROR: $1 not detected as an executable"; exit 1; }
 }
 


### PR DESCRIPTION
f9b67b3 reverted the shell-compatibility changes done in 684436a

This makes the yocto build fail, as it doesn't require bash, see https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/11453074755
`ERROR: mender-orchestrator-support-main-git-r0 do_package_qa: QA Issue: /usr/share/mender-orchestrator/interfaces/v1/rtos contained in package mender-orchestrator-support requires /bin/bash, but no providers found in RDEPENDS:mender-orchestrator-support? [file-rdeps]`