### PR TITLE
fix: add Identity to demo rtos interface

### DIFF
--- a/demo/mock-env/interfaces/v1/rtos
+++ b/demo/mock-env/interfaces/v1/rtos
@@ -125,6 +125,11 @@ case "$STATE" in
 
         ;;
 
+
+    Identity)
+        [ -f "$INSTANCE_DIR/$STATE.FAIL" ] && { log "Failing $STATE"; exit 1; }
+        cat $INSTANCE_DIR/Identity
+        ;;
 esac
 
 # These are when the CLI is invoked with Provides or Inventory. We just duplicate them here, but


### PR DESCRIPTION
We forgot to add identity state to the demo rtos interface

Ticket: None
Changelog: Title