### PR TITLE
fix: Handle identity extraction in the rootfs-image interface script more carefully

### DIFF
--- a/interfaces/v1/rootfs-image
+++ b/interfaces/v1/rootfs-image
@@ -120,7 +120,7 @@ case "$STATE" in
     Identity)
         if [ "$STATE" = "Identity" ]; then
             [ -f "$INSTANCE_DIR/$STATE.FAIL" ] && { log "Failing $STATE"; exit 1; }
-            id=$(/usr/share/mender/identity/mender-device-identity | sed -n 's/^mac=//p')
+            id=$(/usr/share/mender/identity/mender-device-identity | sed -rn '1s/^[^=]+=//p')
             echo "id=$id"
         fi
         ;;


### PR DESCRIPTION
Output from the
`/usr/share/mender/identity/mender-device-identity` script can contain multiple values (because device identity can be a combination of multiple key-value pairs), but for the interface identity we just need a single value. Let's use the first value which should be good enough because the component identity must only be unique in the particular System.

Also, stop assuming that
`/usr/share/mender/identity/mender-device-identity` script always uses a MAC address, it can be an arbitrary unique key-value pair.

Ticket: MEN-9547
Changelog: Fix how identity for the rootfs-image components is extracted from /usr/share/mender/identity/mender-device-identity