### PR TITLE
fix: Parse manifest YAML with yq for system_type compatibility

### DIFF
--- a/modules/mender-orchestrator-manifest/module-artifact-gen/mender-orchestrator-manifest-gen
+++ b/modules/mender-orchestrator-manifest/module-artifact-gen/mender-orchestrator-manifest-gen
@@ -38,19 +38,21 @@ check_manifest_compatibility() {
     local manifest_file="$1"
     local system_types="$2"
 
-    # Manifest file, containing line like:
-    # system_types_compatible: ["system-core", "aaa-bbb", "aaa-bbb2", "text", "010101", "qwe123"]
-    local m_types=$(grep '^system_types_compatible:' $manifest_file | grep -oE '"[^"]+"' | tr -d '"')
+    local m_types=$(yq -r '.system_types_compatible[]?' "$manifest_file")
     # system_types from argument list, sample input:
     # "-t aaa-bbb -t qwe123"
     local s_types=$(echo $system_types | awk '{for(i=1;i<=NF;i++) if($i=="-t") print $(i+1)}')
 
     for item in $s_types; do
-        echo $m_types | grep -q "\b$item\b"
-        if [ $? -eq 0 ]; then
+        # -F: treat manifest entries as fixed strings, never regular
+        #     expressions, so malformed/malicious entries cannot inject
+        #     pattern syntax.
+        # -x: require a whole-line match so we compare full entries instead
+        #     of substrings.
+        if printf '%s\n' "$m_types" | grep -qFx -- "$item"; then
             echo "Found matching system_type: ${item} in manifest entries"
         else
-            echo "Not matching system_type: ${item} found in the manifest entries" 1>&2
+            echo "No matching system_type: '${item}' found in the manifest entries" 1>&2
             exit 1
         fi
     done
@@ -60,6 +62,11 @@ check_manifest_compatibility() {
 
 if ! check_dependency mender-artifact; then
     echo "Please follow the instructions here to install mender-artifact and then try again: https://docs.mender.io/downloads#mender-artifact" 1>&2
+    exit 1
+fi
+
+if ! check_dependency yq; then
+    echo "yq is required to parse the YAML manifest." 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
Ticket: MEN-9720
Changelog: Fix manifest compatibility check failing on unquoted or non-double-quoted system_types_compatible entries. Handle all YAML string syntax. mender-orchestrator-manifest-gen now required yq to work.